### PR TITLE
Update JsfDownloadableLibraryLocationTests for newer JSF libraries

### DIFF
--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Automatic-Module-Name: org.eclipse.jst.jsf.core.tests
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.jst.jsf.core.tests;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.100.qualifier
 Bundle-Activator: org.eclipse.jst.jsf.core.tests.TestsPlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/pom.xml
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.eclipse.webtools.jsf</groupId>
   <artifactId>org.eclipse.jst.jsf.core.tests</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
@@ -51,6 +51,8 @@ public class JsfDownloadableLibraryLocationTests extends TestCase {
 	private static final String CATALOG_URL_PREFIX = "https://www.eclipse.org/webtools/jsf/jsf-library";
 	//@formatter:off
 	private static final String[] CATALOG_URLS = {
+			CATALOG_URL_PREFIX + "/jsf-2.3-downloadable-libraries.xml",
+			CATALOG_URL_PREFIX + "/jsf-2.2-downloadable-libraries.xml",
 			CATALOG_URL_PREFIX + "/jsf-2.1-downloadable-libraries.xml",
 			CATALOG_URL_PREFIX + "/jsf-2.0-downloadable-libraries.xml",
 			CATALOG_URL_PREFIX + "/jsf-1.2-downloadable-libraries.xml",

--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
@@ -48,7 +48,7 @@ import org.xml.sax.SAXException;
  *
  */
 public class JsfDownloadableLibraryLocationTests extends TestCase {
-	private static final String CATALOG_URL_PREFIX = "http://www.eclipse.org/webtools/jsf/jsf-library";
+	private static final String CATALOG_URL_PREFIX = "https://www.eclipse.org/webtools/jsf/jsf-library";
 	//@formatter:off
 	private static final String[] CATALOG_URLS = {
 			CATALOG_URL_PREFIX + "/jsf-2.1-downloadable-libraries.xml",

--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/src/org/eclipse/jst/jsf/core/tests/facet/JsfDownloadableLibraryLocationTests.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2001, 2012 Oracle Corporation and others.
+ * Copyright (c) 2001, 2024 Oracle Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,189 +41,152 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-
 /**
  * Tests for JSF downloadable-library locations.
  *
  * @author Debajit Adhikary
  *
  */
-public class JsfDownloadableLibraryLocationTests extends TestCase
-{
-    private static final String CATALOG_URL_PREFIX = "http://www.eclipse.org/webtools/jsf/jsf-library";
-    private static final String[] CATALOG_URLS =
-    {
-    	CATALOG_URL_PREFIX + "/jsf-2.1-downloadable-libraries.xml",
-        CATALOG_URL_PREFIX + "/jsf-2.0-downloadable-libraries.xml",
-        CATALOG_URL_PREFIX + "/jsf-1.2-downloadable-libraries.xml",
-        CATALOG_URL_PREFIX + "/jsf-1.1-downloadable-libraries.xml"
-    };
+public class JsfDownloadableLibraryLocationTests extends TestCase {
+	private static final String CATALOG_URL_PREFIX = "http://www.eclipse.org/webtools/jsf/jsf-library";
+	//@formatter:off
+	private static final String[] CATALOG_URLS = {
+			CATALOG_URL_PREFIX + "/jsf-2.1-downloadable-libraries.xml",
+			CATALOG_URL_PREFIX + "/jsf-2.0-downloadable-libraries.xml",
+			CATALOG_URL_PREFIX + "/jsf-1.2-downloadable-libraries.xml",
+			CATALOG_URL_PREFIX + "/jsf-1.1-downloadable-libraries.xml"
+	};
+	//@formatter:on
 
-    private Proxy httpProxy = Proxy.NO_PROXY;
-    private final List<String> downloadUrls;
+	private Proxy httpProxy = Proxy.NO_PROXY;
+	private final List<String> downloadUrls;
 
+	/**
+	 * @param name
+	 */
+	public JsfDownloadableLibraryLocationTests(final String name) {
+		super(name);
+		downloadUrls = new ArrayList<String>();
+	}
 
-    /**
-     * @param name
-     */
-    public JsfDownloadableLibraryLocationTests (final String name)
-    {
-        super(name);
-        downloadUrls = new ArrayList<String>();
-    }
+	/**
+	 * Extracts the downloadable library URL's from the catalog files and adds them
+	 * to the downloadUrls list.
+	 *
+	 * @see junit.framework.TestCase#setUp()
+	 */
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
 
+		setProxy();
 
-    /**
-     * Extracts the downloadable library URL's from the catalog files and adds
-     * them to the downloadUrls list.
-     *
-     * @see junit.framework.TestCase#setUp()
-     */
-    @Override
-    protected void setUp () throws Exception
-    {
-        super.setUp();
+		for (final String catalog : CATALOG_URLS) {
+			// Extract the download-library url
+			final Document document = getXmlDocument(catalog);
+			final NodeList nodes = evaluateXpathQuery(document, "//download-url/text()");
+			for (int i = 0; i < nodes.getLength(); ++i) {
+				final String downloadUrl = nodes.item(i).getNodeValue();
+				downloadUrls.add(downloadUrl);
+				System.out.println("JSF library download URL (extracted from catalog): " + downloadUrl);
+			}
+		}
+	}
 
-        setProxy();
-
-        for (final String catalog : CATALOG_URLS)
-        {
-            // Extract the download-library url
-            final Document document = getXmlDocument(catalog);
-            final NodeList nodes = evaluateXpathQuery(document, "//download-url/text()");
-            for (int i = 0; i < nodes.getLength(); ++i)
-            {
-                final String downloadUrl = nodes.item(i).getNodeValue();
-                downloadUrls.add(downloadUrl);
-                System.out.println("JSF library download URL (extracted from catalog): " + downloadUrl);
-            }
-        }
-    }
-
-
-    private void setProxy() throws IOException
-    {
-    	final String PROXY_TEST_URL = "http://www.eclipse.org/";
-    	final List<Proxy> possibleProxies = new ArrayList<Proxy>();
-    	//add direct (no proxy)
-    	possibleProxies.add(Proxy.NO_PROXY);
-    	//add system-specified proxy (if any)
-    	final String sysProxyHost = System.getProperty("http.proxyHost");
-    	if (sysProxyHost != null)
-    	{
-    		final String sysProxyPort = System.getProperty("http.proxyPort");
-    		if (sysProxyPort != null)
-    		{
-    			int proxyPort = -1; 
-    			try
-    			{
-    				proxyPort = Integer.parseInt(sysProxyPort);
-    			}
-    			catch (NumberFormatException nfex)
-    			{
-    				//do nothing - proxyPort remains an invalid value
-    			}
-    			if (proxyPort > -1)
-    			{
-    		    	possibleProxies.add(new Proxy(Type.HTTP, new InetSocketAddress(sysProxyHost, proxyPort)));
-    			}
-    		}
-    	}
-    	//add Oracle-specific proxy
-    	possibleProxies.add(new Proxy(Type.HTTP, new InetSocketAddress("www-proxy.us.oracle.com", 80)));
+	private void setProxy() throws IOException {
+		final String PROXY_TEST_URL = "http://www.eclipse.org/";
+		final List<Proxy> possibleProxies = new ArrayList<Proxy>();
+		// add direct (no proxy)
+		possibleProxies.add(Proxy.NO_PROXY);
+		// add system-specified proxy (if any)
+		final String sysProxyHost = System.getProperty("http.proxyHost");
+		if (sysProxyHost != null) {
+			final String sysProxyPort = System.getProperty("http.proxyPort");
+			if (sysProxyPort != null) {
+				int proxyPort = -1;
+				try {
+					proxyPort = Integer.parseInt(sysProxyPort);
+				} catch (NumberFormatException nfex) {
+					// do nothing - proxyPort remains an invalid value
+				}
+				if (proxyPort > -1) {
+					possibleProxies.add(new Proxy(Type.HTTP, new InetSocketAddress(sysProxyHost, proxyPort)));
+				}
+			}
+		}
+		// add Oracle-specific proxy
+		possibleProxies.add(new Proxy(Type.HTTP, new InetSocketAddress("www-proxy.us.oracle.com", 80)));
 		final URL proxyTestURL = new URL(PROXY_TEST_URL);
-    	for (final Proxy proxy: possibleProxies)
-    	{
-    		InputStream is = null;
-        	try
-        	{
-        		final URLConnection connection = proxyTestURL.openConnection(proxy);
-        		is = connection.getInputStream();
-        		//if we get to here, the current proxy is viable
-        		httpProxy = proxy;
-        		break;
-        	}
-        	catch (IOException ioex)
-        	{
-        		//do nothing - current proxy is not viable and was not set
-        	}
-        	finally
-        	{
-        		if (is != null)
-        		{
-        			try
-        			{
-        				is.close();
-        			}
-        			catch (IOException ioex)
-        			{
-        				//do nothing
-        			}
-        		}
-        	}
-    	}
-    }
+		for (final Proxy proxy : possibleProxies) {
+			InputStream is = null;
+			try {
+				final URLConnection connection = proxyTestURL.openConnection(proxy);
+				is = connection.getInputStream();
+				// if we get to here, the current proxy is viable
+				httpProxy = proxy;
+				break;
+			} catch (IOException ioex) {
+				// do nothing - current proxy is not viable and was not set
+			} finally {
+				if (is != null) {
+					try {
+						is.close();
+					} catch (IOException ioex) {
+						// do nothing
+					}
+				}
+			}
+		}
+	}
 
+	/**
+	 * Validates all the downloadable-library URL's extracted from the catalog file.
+	 *
+	 * @throws IOException
+	 */
+	public void testDownloadLibraryUrls() throws IOException {
+		for (final String url : downloadUrls) {
+			assertTrue("Cannot download library from: " + url, isValidUrl(url));
+		}
+	}
 
-    /**
-     * Validates all the downloadable-library URL's extracted from the catalog
-     * file.
-     *
-     * @throws IOException
-     */
-    public void testDownloadLibraryUrls () throws IOException
-    {
-        for (final String url : downloadUrls)
-        {
-            assertTrue("Cannot download library from: " + url, isValidUrl(url));
-        }
-    }
+	private Document getXmlDocument(final String url)
+			throws ParserConfigurationException, MalformedURLException, IOException, SAXException {
+		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final URL catalogUrl = new URL(url);
+		final URLConnection catalogUrlConnection = catalogUrl.openConnection(httpProxy);
+		return builder.parse(catalogUrlConnection.getInputStream());
+	}
 
+	private NodeList evaluateXpathQuery(final Document xmlDocument, final String xpathQuery)
+			throws XPathExpressionException {
+		final XPath xpath = XPathFactory.newInstance().newXPath();
+		final XPathExpression expr = xpath.compile(xpathQuery);
+		return (NodeList) expr.evaluate(xmlDocument, XPathConstants.NODESET);
+	}
 
-    private Document getXmlDocument (final String url)
-    throws ParserConfigurationException, MalformedURLException, IOException, SAXException
-    {
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(true);
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        final URL catalogUrl = new URL(url);
-        final URLConnection catalogUrlConnection = catalogUrl.openConnection(httpProxy);
-        return builder.parse(catalogUrlConnection.getInputStream());
-    }
-
-
-    private NodeList evaluateXpathQuery (final Document xmlDocument,
-                                         final String xpathQuery)
-    throws XPathExpressionException
-    {
-        final XPath xpath = XPathFactory.newInstance().newXPath();
-        final XPathExpression expr = xpath.compile(xpathQuery);
-        return (NodeList) expr.evaluate(xmlDocument, XPathConstants.NODESET);
-    }
-
-
-    /**
-     * Validates a URL by connecting to it and checking the HTTP response code.
-     *
-     * @param urlString
-     *            URL to check.
-     *
-     * @return True if the HTTP response code indicates success (Response code
-     *         2xx. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
-     *
-     * @throws IOException
-     */
-    private boolean isValidUrl (final String urlString) throws IOException
-    {
-        final URL url = new URL(urlString);
-        final HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection(httpProxy);
-        urlConnection.connect();
-        int responseCode = -1;
-        try {
-        	responseCode = urlConnection.getResponseCode();
-        } catch(SocketException sockEx) {
-        	//ignore and proceed with response code == -1
-        }
-        return 200 <= responseCode && responseCode <= 299;
-    }
+	/**
+	 * Validates a URL by connecting to it and checking the HTTP response code.
+	 *
+	 * @param urlString URL to check.
+	 *
+	 * @return True if the HTTP response code indicates success (Response code 2xx.
+	 *         See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+	 *
+	 * @throws IOException
+	 */
+	private boolean isValidUrl(final String urlString) throws IOException {
+		final URL url = new URL(urlString);
+		final HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection(httpProxy);
+		urlConnection.connect();
+		int responseCode = -1;
+		try {
+			responseCode = urlConnection.getResponseCode();
+		} catch (SocketException sockEx) {
+			// ignore and proceed with response code == -1
+		}
+		return 200 <= responseCode && responseCode <= 299;
+	}
 }


### PR DESCRIPTION
These are the changes for `JsfDownloadableLibraryLocationTests` mentioned in the pull request for the website at https://gitlab.eclipse.org/eclipse/webtools/webtools-website/-/merge_requests/3 .