### PR TITLE
Bump Java 17 -> 21

### DIFF
--- a/jsf/plugins/org.eclipse.jst.jsf.apache.trinidad.tagsupport/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.apache.trinidad.tagsupport/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.jst.jsf.common.ui;bundle-version="[1.1.0,2.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jst.jsf.apache.trinidad.tagsupport;x-internal:=true,
  org.eclipse.jst.jsf.apache.trinidad.tagsupport.converter.operations;x-internal:=true,

--- a/jsf/plugins/org.eclipse.jst.jsf.common.runtime/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.common.runtime/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.5.0.qualifier
 Bundle-Activator: org.eclipse.jst.jsf.common.runtime.internal.JSFCommonRuntimePlugin
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.common.runtime.internal;x-internal:=true,
  org.eclipse.jst.jsf.common.runtime.internal.debug;x-friends:="org.eclipse.jst.jsf.common.runtime.tests",
  org.eclipse.jst.jsf.common.runtime.internal.model;x-friends:="org.eclipse.jst.jsf.common.runtime.tests",

--- a/jsf/plugins/org.eclipse.jst.jsf.common.ui/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.common.ui/META-INF/MANIFEST.MF
@@ -34,4 +34,4 @@ Export-Package: org.eclipse.jst.jsf.common.ui;x-friends:="org.eclipse.jst.pagede
  org.eclipse.jst.jsf.common.ui.internal.utils;x-friends:="org.eclipse.jst.pagedesigner,org.eclipse.jst.jsf.facesconfig.ui,org.eclipse.jst.pagedesigner.jsf.ui"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %pluginProvider
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.jsf.common/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.common/META-INF/MANIFEST.MF
@@ -78,5 +78,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.j2ee.core
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %plugin.provider
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.eclipse.jst.javaee.web.internal.impl

--- a/jsf/plugins/org.eclipse.jst.jsf.core/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.core/META-INF/MANIFEST.MF
@@ -119,4 +119,4 @@ Export-Package: org.eclipse.jst.jsf.core,
  org.eclipse.jst.jsf.validation.internal.el.operators;x-internal:=true,
  org.eclipse.jst.jsf.validation.internal.facelet,
  org.eclipse.jst.jsf.validation.internal.strategy;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.jsf.facelet.core/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.facelet.core/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jst.j2ee.core;bundle-version="[1.2.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.facelet.core.internal;x-internal:=true,
  org.eclipse.jst.jsf.facelet.core.internal.cm;x-internal:=true,
  org.eclipse.jst.jsf.facelet.core.internal.cm.addtagmd;x-friends:="org.eclipse.jst.jsf.facelet.tagsupport",

--- a/jsf/plugins/org.eclipse.jst.jsf.facelet.ui/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.facelet.ui/META-INF/MANIFEST.MF
@@ -32,7 +32,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jst.jsf.ui;bundle-version="1.0.1",
  org.eclipse.jst.jsf.facelet.core;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.facelet.ui.internal;x-internal:=true,
  org.eclipse.jst.jsf.facelet.ui.internal.contentassist;x-internal:=true,
  org.eclipse.jst.jsf.facelet.ui.internal.facet;x-internal:=true,

--- a/jsf/plugins/org.eclipse.jst.jsf.facesconfig.ui/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.facesconfig.ui/META-INF/MANIFEST.MF
@@ -55,4 +55,4 @@ Export-Package: org.eclipse.jst.jsf.facesconfig.ui;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.ui.section;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.ui.util;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.ui.wizard;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.jsf.facesconfig/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.facesconfig/META-INF/MANIFEST.MF
@@ -30,4 +30,4 @@ Export-Package: org.eclipse.jst.jsf.facesconfig,
  org.eclipse.jst.jsf.facesconfig.internal.nls;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.internal.translator;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.util
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.jsf.standard.tagsupport/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.standard.tagsupport/META-INF/MANIFEST.MF
@@ -11,6 +11,6 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.jsf.common;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.emf.ecore.xmi;bundle-version="[2.2.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.standard.tagsupport;x-internal:=true
 Bundle-Vendor: %pluginProvider

--- a/jsf/plugins/org.eclipse.jst.jsf.ui/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.jsf.ui/META-INF/MANIFEST.MF
@@ -44,4 +44,4 @@ Export-Package: org.eclipse.jst.jsf.ui.internal;x-friends:="org.eclipse.jst.jsf.
  org.eclipse.jst.jsf.ui.internal.project.facet;x-friends:="org.eclipse.jst.jsf.ui.tests",
  org.eclipse.jst.jsf.ui.internal.tagregistry;x-internal:=true,
  org.eclipse.jst.jsf.ui.internal.validation;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.pagedesigner.jsf.ui/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.pagedesigner.jsf.ui/META-INF/MANIFEST.MF
@@ -39,4 +39,4 @@ Export-Package: org.eclipse.jst.pagedesigner.jsf.core.dom;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsf.ui.elementedit.util;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsf.ui.sections;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsf.ui.util;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.pagedesigner.jsp.core/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.pagedesigner.jsp.core/META-INF/MANIFEST.MF
@@ -22,4 +22,4 @@ Export-Package: org.eclipse.jst.pagedesigner.jsp.core;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsp.core.pagevar;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsp.core.pagevar.adapter;x-internal:=true,
  org.eclipse.jst.pagedesigner.jsp.core.util;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/plugins/org.eclipse.jst.pagedesigner/META-INF/MANIFEST.MF
+++ b/jsf/plugins/org.eclipse.jst.pagedesigner/META-INF/MANIFEST.MF
@@ -120,7 +120,7 @@ Export-Package: org.eclipse.jst.pagedesigner;x-internal:=true,
  org.eclipse.jst.pagedesigner.utils;x-internal:=true,
  org.eclipse.jst.pagedesigner.validation.caret;x-internal:=true,
  org.eclipse.jst.pagedesigner.viewer;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: javax.servlet.jsp.el;version="2.0.0"
 Automatic-Module-Name: org.eclipse.jst.pagedesigner
 

--- a/jsf/tests/org.eclipse.jst.jsf.common.runtime.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.common.runtime.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jst.jsf.common.runtime;bundle-version="[1.0.0,2.0.0)",
  org.junit;bundle-version="3.8.1"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.common.runtime.tests.model
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/jsf/tests/org.eclipse.jst.jsf.contentassist.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.contentassist.tests/META-INF/MANIFEST.MF
@@ -24,6 +24,6 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.emf.ecore,
  org.eclipse.wst.common.project.facet.core;bundle-version="[1.5.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.contentassist.tests;x-internal:=true
 Bundle-Vendor: %Bundle-Vendor.0

--- a/jsf/tests/org.eclipse.jst.jsf.context.symbol.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.context.symbol.tests/META-INF/MANIFEST.MF
@@ -23,4 +23,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.jsf.core;bundle-version="1.1.103"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.jst.jsf.context.symbol.tests.ContextSymbolTestPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/tests/org.eclipse.jst.jsf.core.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.core.tests/META-INF/MANIFEST.MF
@@ -55,4 +55,4 @@ Export-Package: org.eclipse.jst.jsf.core.tests;x-friends:="org.eclipse.jst.jsf.u
    org.eclipse.jst.pagedesigner.tests",
  org.eclipse.jst.jsf.core.tests.validation
 Plugin-Class: org.eclipse.jst.jsf.core.tests.TestsPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/tests/org.eclipse.jst.jsf.designtime.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.designtime.tests/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.jsf.common.runtime.tests;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.jdt.core.manipulation;bundle-version="[1.3.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.designtime.tests;x-internal:=true,
  org.eclipse.jst.jsf.designtime.tests.resources
 Bundle-Vendor: %Bundle-Vendor.0

--- a/jsf/tests/org.eclipse.jst.jsf.facesconfig.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.facesconfig.tests/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.jsf.test.util;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.jst.jsf.core;bundle-version="[1.1.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.facesconfig.tests;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.tests.read;x-internal:=true,
  org.eclipse.jst.jsf.facesconfig.tests.util;x-internal:=true,

--- a/jsf/tests/org.eclipse.jst.jsf.facesconfig.ui.test/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.facesconfig.ui.test/META-INF/MANIFEST.MF
@@ -9,5 +9,5 @@ Fragment-Host: org.eclipse.jst.jsf.facesconfig.ui;bundle-version="[1.0.0,2.0.0)"
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.jst.jsf.test.util;bundle-version="[1.0.0,2.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 

--- a/jsf/tests/org.eclipse.jst.jsf.metadata.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.metadata.tests/META-INF/MANIFEST.MF
@@ -38,5 +38,5 @@ Export-Package: org.eclipse.jst.jsf.common.metadata.tests;x-internal:=true,
  org.eclipse.jst.jsf.metadata.tests.metadataprocessing.types;x-internal:=true,
  org.eclipse.jst.jsf.metadata.tests.taglibprocessing;x-internal:=true
 Plugin-Class: org.eclipse.jst.jsf.metadata.tests.MetadataTestsPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor.0

--- a/jsf/tests/org.eclipse.jst.jsf.metadataprocessingtests2/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.metadataprocessingtests2/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jst.jsf.core;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.jst.jsf.common;bundle-version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.metadataprocessingtests2;x-internal:=true
 Bundle-Vendor: %Bundle-Vendor.0

--- a/jsf/tests/org.eclipse.jst.jsf.test.util/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.test.util/META-INF/MANIFEST.MF
@@ -39,5 +39,5 @@ Export-Package: org.eclipse.jst.jsf.test.util,
  org.eclipse.jst.jsf.test.util.mock.osgi,
  org.eclipse.jst.jsf.test.util.mock.smodel
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %Bundle-Vendor.0

--- a/jsf/tests/org.eclipse.jst.jsf.ui.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.ui.tests/META-INF/MANIFEST.MF
@@ -27,4 +27,4 @@ Require-Bundle: org.eclipse.jst.jsf.core;bundle-version="[1.1.0,2.0.0)",
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jst.jsf.ui.tests;x-internal:=true,
  org.eclipse.jst.jsf.ui.tests.util;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/jsf/tests/org.eclipse.jst.jsf.validation.el.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.jsf.validation.el.tests/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="2.4.1",
  org.eclipse.jst.common.project.facet.core
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jst.jsf.validation.el.tests;x-internal:=true,
  org.eclipse.jst.jsf.validation.el.tests.base;x-internal:=true,
  org.eclipse.jst.jsf.validation.el.tests.jsp;x-internal:=true,

--- a/jsf/tests/org.eclipse.jst.pagedesigner.tests/META-INF/MANIFEST.MF
+++ b/jsf/tests/org.eclipse.jst.pagedesigner.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.jst.pagedesigner.tests;singleton:=true
 Bundle-Version: 1.6.2.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.jst.jsf.test.util;bundle-version="[1.0.0,2.0.0)",


### PR DESCRIPTION
WebTools JSF depends on core Eclipse plugins, that use Java 21 